### PR TITLE
Fixed linked list for Sitecore 7.2 and above. 

### DIFF
--- a/App_Config/Includes/Monoco.CMS.FieldTypes.config
+++ b/App_Config/Includes/Monoco.CMS.FieldTypes.config
@@ -15,6 +15,7 @@
 
     <settings>
       <setting name="Monoco.CMS.Linklist.SitecoreVersionIsPre7.2" value="true" />
+      <setting name="Monoco.CMS.Linklist.SitecoreVersionIsPre7.5" value="true" />
     </settings>
     
   </sitecore>

--- a/App_Config/Includes/Monoco.CMS.FieldTypes.config
+++ b/App_Config/Includes/Monoco.CMS.FieldTypes.config
@@ -12,6 +12,10 @@
         <processor x:before="*[1]" type="Monoco.CMS.Pipelines.RenderContentEditor.AddLinkListScripts,Monoco.CMS"/>
       </renderContentEditor>
     </pipelines>
+
+    <settings>
+      <setting name="Monoco.CMS.Linklist.SitecoreVersionIsPre7.2" value="true" />
+    </settings>
     
   </sitecore>
 </configuration>

--- a/sitecore modules/Shell/FieldTypes/LinkListField.cs
+++ b/sitecore modules/Shell/FieldTypes/LinkListField.cs
@@ -113,7 +113,7 @@ namespace Monoco.CMS.FieldTypes
                 // Sitecore 7.2 uses urlHandle to transfer the va variable, 
                 // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
                 var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
-                if (isPre72Version)
+                if (isPre72Version || args.Parameters["url"] == InternalLinkDialogUrl)
                 {
                     urlString.Append("va", node.OuterXml);
                 }
@@ -180,7 +180,7 @@ namespace Monoco.CMS.FieldTypes
                 // Sitecore 7.2 uses urlHandle to transfer the va variable, 
                 // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
                 var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
-                if (isPre72Version)
+                if (isPre72Version || args.Parameters["url"] == InternalLinkDialogUrl)
                 {
                     urlString.Append("va", XmlValue.ToString());
                 }

--- a/sitecore modules/Shell/FieldTypes/LinkListField.cs
+++ b/sitecore modules/Shell/FieldTypes/LinkListField.cs
@@ -113,7 +113,8 @@ namespace Monoco.CMS.FieldTypes
                 // Sitecore 7.2 uses urlHandle to transfer the va variable, 
                 // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
                 var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
-                if (isPre72Version || args.Parameters["url"] == InternalLinkDialogUrl)
+                var isPre75Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.5", false);
+                if (isPre72Version || (isPre75Version && args.Parameters["url"] == InternalLinkDialogUrl))
                 {
                     urlString.Append("va", node.OuterXml);
                 }
@@ -180,7 +181,8 @@ namespace Monoco.CMS.FieldTypes
                 // Sitecore 7.2 uses urlHandle to transfer the va variable, 
                 // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
                 var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
-                if (isPre72Version || args.Parameters["url"] == InternalLinkDialogUrl)
+                var isPre75Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.5", false);
+                if (isPre72Version || (isPre75Version && args.Parameters["url"] == InternalLinkDialogUrl))
                 {
                     urlString.Append("va", XmlValue.ToString());
                 }

--- a/sitecore modules/Shell/FieldTypes/LinkListField.cs
+++ b/sitecore modules/Shell/FieldTypes/LinkListField.cs
@@ -8,6 +8,7 @@ using Sitecore.Diagnostics;
 using Sitecore.Resources;
 using Sitecore.Shell.Applications.ContentEditor;
 using Sitecore.Text;
+using Sitecore.Web;
 using Sitecore.Web.UI.Sheer;
 
 namespace Monoco.CMS.FieldTypes
@@ -108,7 +109,20 @@ namespace Monoco.CMS.FieldTypes
             else
             {
                 var urlString = new UrlString(args.Parameters["url"]);
-                urlString.Append("va", node.OuterXml);
+
+                // Sitecore 7.2 uses urlHandle to transfer the va variable, 
+                // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
+                var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
+                if (isPre72Version)
+                {
+                    urlString.Append("va", node.OuterXml);
+                }
+                else
+                {
+                    var urlHandle = new UrlHandle();
+                    urlHandle["va"] = node.OuterXml;
+                    urlHandle.Add(urlString);
+                }
                 urlString.Append("ro", Source);
                 Sitecore.Context.ClientPage.ClientResponse.ShowModalDialog(urlString.ToString(), true);
                 args.WaitForPostBack();
@@ -162,7 +176,20 @@ namespace Monoco.CMS.FieldTypes
             {
                 // Show the dialog using ShowModalDialog.
                 var urlString = new UrlString(args.Parameters["url"]);
-                urlString.Append("va", XmlValue.ToString());
+                
+                // Sitecore 7.2 uses urlHandle to transfer the va variable, 
+                // so if we're 7.2 or above, use UrlHandle, otherwise, use urlString
+                var isPre72Version = Sitecore.Configuration.Settings.GetBoolSetting("Monoco.CMS.Linklist.SitecoreVersionIsPre7.2", false);
+                if (isPre72Version)
+                {
+                    urlString.Append("va", XmlValue.ToString());
+                }
+                else
+                {
+                    var urlHandle = new UrlHandle();
+                    urlHandle["va"] = XmlValue.ToString();
+                    urlHandle.Add(urlString);
+                }
                 urlString.Append("ro", Source);
                 Sitecore.Context.ClientPage.ClientResponse.ShowModalDialog(urlString.ToString(), true);
                 args.WaitForPostBack();


### PR DESCRIPTION
Sitecore 7.2 uses urlhandle to transfer data to the dialog whereas 7.1 and below use the urlstring.

Added a setting so the developer can specify if we're using Sitecore 7.2 and above, or 7.1 or below.
Modified the linklistfield class to choose how to send the data to the dialog based on the setting

Note: setting is currently set to true, meaning that the functionality doesn't change for current usage. Set to false if you want to use 7.2 or above. 
